### PR TITLE
[고도화] mariaDB -> PostgreSQL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ repositories {
 
 dependencies {
 
+    runtimeOnly 'org.postgresql:postgresql'
+
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -18,10 +18,9 @@ logging:
 spring:
 
   datasource:
-    url: jdbc:mariadb://localhost:3306/board
-    username: minzino
+    url: jdbc:postgresql://localhost:5432/board
+    username: imin-yong
     password: thisisTESTpw!@#$
-    driver-class-name: org.mariadb.jdbc.Driver
   jpa:
     open-in-view: false
     defer-datasource-initialization: true


### PR DESCRIPTION
mariadb -> postgresql 로 변경완료

처음사용해보는 RDB인 Postgresql 로 변경  JPA 덕분인지 손쉽게 이동이 가능한것 같다 

서비스 로직을 짜보며 기존과 다른점이 있는지 체크해보자

This closes #48 